### PR TITLE
Get rid of maven warnings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
   <version>0.10-SNAPSHOT</version>
 
   <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- Convenience property to set the GWT version -->
     <gwt.version>2.4.0</gwt.version>
     <maven.compiler.source>1.6</maven.compiler.source>
@@ -56,6 +57,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.1</version>
+        <configuration>
+          <quiet>true</quiet>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
Another tweak to the build file to get rid of maven warnings about file encodings, and make the javadoc build output less verbose.
